### PR TITLE
Throws an exception if the property is empty

### DIFF
--- a/SQLInjectionCheckerLib/SQLInjectionCheckerUtils.cs
+++ b/SQLInjectionCheckerLib/SQLInjectionCheckerUtils.cs
@@ -84,7 +84,8 @@ namespace SQLInjectionCheckerLib
 
                 foreach(PropertyInfo prop in properties)
                 {
-                    string propValue = prop.GetValue(Obj, null).ToString();
+                    object propValueObj = prop.GetValue(Obj, null);
+                    string propValue = propValueObj == null ? "" : propValueObj.ToString();
 
                     if (propValue.CheckForSQLInjection())
                     {


### PR DESCRIPTION
Object reference not set to an instance of an object.
NullReferenceException: Object reference not set to an instance of an object.